### PR TITLE
Ability to control if fragments should always have a newline at the end.

### DIFF
--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -44,6 +44,7 @@ TEST=""
 FORCE=""
 WARN=""
 SORTARG=""
+ENSURE_NEW_LINE=""
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 
@@ -59,6 +60,7 @@ while getopts "o:s:d:tnw:f" options; do
 		w ) WARNMSG="$OPTARG";;
 		f ) FORCE="true";;
 		t ) TEST="true";;
+		l ) ENSURE_NEW_LINE="true";;
 		* ) echo "Specify output file with -o and fragments directory with -d"
 		    exit 1;;
 	esac
@@ -109,6 +111,10 @@ if [ x${WARNMSG} = "x" ]; then
 	: > "fragments.concat"
 else
 	printf '%s\n' "$WARNMSG" > "fragments.concat"
+fi
+
+if [ x${ENSURE_NEW_LINE} != x ]; then
+	find fragments/ -type f -follow -print0 | xargs -0 -I '{}' sh -c 'if [ -n "$(tail -c 1 < {} )" ]; then echo >> {} ; fi'
 fi
 
 # find all the files in the fragments directory, sort them numerically and concat to fragments.concat in the working dir

--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -52,7 +52,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 ## http://nexenta.org/projects/site/wiki/Personalities
 unset SUN_PERSONALITY
 
-while getopts "o:s:d:tnw:f" options; do
+while getopts "o:s:d:tnw:fl" options; do
 	case $options in
 		o ) OUTFILE=$OPTARG;;
 		d ) WORKDIR=$OPTARG;;

--- a/files/concatfragments.sh
+++ b/files/concatfragments.sh
@@ -44,7 +44,7 @@ TEST=""
 FORCE=""
 WARN=""
 SORTARG=""
-ENSURE_NEW_LINE=""
+ENSURE_NEWLINE=""
 
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 
@@ -60,7 +60,7 @@ while getopts "o:s:d:tnw:fl" options; do
 		w ) WARNMSG="$OPTARG";;
 		f ) FORCE="true";;
 		t ) TEST="true";;
-		l ) ENSURE_NEW_LINE="true";;
+		l ) ENSURE_NEWLINE="true";;
 		* ) echo "Specify output file with -o and fragments directory with -d"
 		    exit 1;;
 	esac
@@ -113,7 +113,7 @@ else
 	printf '%s\n' "$WARNMSG" > "fragments.concat"
 fi
 
-if [ x${ENSURE_NEW_LINE} != x ]; then
+if [ x${ENSURE_NEWLINE} != x ]; then
 	find fragments/ -type f -follow -print0 | xargs -0 -I '{}' sh -c 'if [ -n "$(tail -c 1 < {} )" ]; then echo >> {} ; fi'
 fi
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,7 +130,8 @@ define concat(
   $force = false,
   $backup = 'puppet',
   $gnu = undef,
-  $order='alpha'
+  $order='alpha',
+  $ensure_new_line = false
 ) {
   include concat::setup
 
@@ -183,6 +184,18 @@ define concat(
     }
   }
 
+  case $ensure_new_line {
+    'true', true, yes, on: {
+      $newlineflag = '-l'
+    }
+    'false', false, no, off: {
+      $newlineflag = ''
+    }
+    default: {
+      fail("Improper 'ensure_new_line' value given to concat: ${ensure_new_line}")
+    }
+  }
+
   File {
     owner  => $::id,
     group  => $group,
@@ -229,7 +242,7 @@ define concat(
 
   exec { "concat_${name}":
     alias       => "concat_${fragdir}",
-    command     => "${concat::setup::concatdir}/bin/concatfragments.sh -o ${fragdir}/${concat_name} -d ${fragdir} ${warnflag} ${forceflag} ${orderflag}",
+    command     => "${concat::setup::concatdir}/bin/concatfragments.sh -o ${fragdir}/${concat_name} -d ${fragdir} ${warnflag} ${forceflag} ${orderflag} ${newlineflag}",
     notify      => File[$name],
     require     => [
       File[$fragdir],
@@ -237,7 +250,7 @@ define concat(
       File["${fragdir}/fragments.concat"],
     ],
     subscribe   => File[$fragdir],
-    unless      => "${concat::setup::concatdir}/bin/concatfragments.sh -o ${fragdir}/${concat_name} -d ${fragdir} -t ${warnflag} ${forceflag} ${orderflag}",
+    unless      => "${concat::setup::concatdir}/bin/concatfragments.sh -o ${fragdir}/${concat_name} -d ${fragdir} -t ${warnflag} ${forceflag} ${orderflag} ${newlineflag}",
   }
 
   if $::id == 'root' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,7 +131,7 @@ define concat(
   $backup = 'puppet',
   $gnu = undef,
   $order='alpha',
-  $ensure_new_line = false
+  $ensure_newline = false
 ) {
   include concat::setup
 
@@ -184,7 +184,7 @@ define concat(
     }
   }
 
-  case $ensure_new_line {
+  case $ensure_newline {
     'true', true, yes, on: {
       $newlineflag = '-l'
     }
@@ -192,7 +192,7 @@ define concat(
       $newlineflag = ''
     }
     default: {
-      fail("Improper 'ensure_new_line' value given to concat: ${ensure_new_line}")
+      fail("Improper 'ensure_newline' value given to concat: ${ensure_newline}")
     }
   }
 


### PR DESCRIPTION
Configurably handle files which lack newlines.

This appears to work but is not reversible. Still investigating.
